### PR TITLE
Added Two New Macros to iditacard.cls

### DIFF
--- a/iditacard.cls
+++ b/iditacard.cls
@@ -60,6 +60,13 @@
 \fill [health] (50.0/300.0,800.0/300.0) rectangle (250.0/300.0,700.0/300.0) node [text=black,pos=0.5] {\bf\fontsize{25}{30}\bebas #1};
 }
 
+\newcommand{\@condcost}[2]{\ifnum 0<#1#2\fi}
+\newcommand{\costs}[3]{%
+\@condcost{#1}{\energy{#1}}%
+\@condcost{#2}{\health{#2}}%
+\@condcost{#3}{\risk{#3}}%
+}
+
 \newcommand{\risk}[1]{%
 \fill [risk] (50.0/300.0,650.0/300.0) rectangle (250.0/300.0,550.0/300.0) node [text=white,pos=0.5] {\bf\fontsize{25}{30}\bebas #1};
 }
@@ -111,3 +118,13 @@
 }
 {% End
 \end{tikzpicture}}
+
+\newenvironment{playcard}[3][@]
+{% Begin
+\cardtype{#2}\rarity{#3}
+\begin{card}
+\type{\if #1@#2\else#1 #2\fi}
+}
+{% End
+\end{card}
+}

--- a/test.tex
+++ b/test.tex
@@ -1,18 +1,13 @@
 % Compile with XeLaTeX
+% Now tests new features!
 \documentclass{iditacard}
 % Montage with `montage -tile 3x3 -geometry 750x1050+50+25 in* out.pdf`
 
-\cardtype{utility}
-\rarity{legendary}
-
 \begin{document}
-\begin{card}
-\energy{1}
-\health{2}
-\risk{3}
+\begin{playcard}[special]{utility}{legendary}
+\costs{1}{2}{3}
 \name{Example Card}
 \text{Move 10 myrameters. Shuffle your discard pile into your deck.}
 \flava{What doesn't kill you makes you stronger.}
-\type{utility}
-\end{card}
+\end{playcard}
 \end{document}


### PR DESCRIPTION
Neither adds any new functionality, but both cut out several lines of bloat in each card definition.

\costs{energy}{health}{risk}
Wraps up the trio of calls to the cost marker macros. Each parameter is passed to the cost printing macro of the same name, except if it the cost is 0, in which case the macro is omitted.

\begin{playcard}[subtype]{cardtype}{rarity}
\end{playcard}
An extension of the card environment. The subtype is optional, it is combined to create the card's type label if provided, as a prefix (as all current subtypes work). If omitted, the cardtype is used by itself. Cardtype and rarity also are used to generate the card colours.